### PR TITLE
#38: Add the PHQ-9 questionnaire

### DIFF
--- a/public/content/PHQ-9.json
+++ b/public/content/PHQ-9.json
@@ -1,0 +1,996 @@
+{
+    "resourceType": "Questionnaire",
+    "id": "44249-1",
+    "meta": {
+        "versionId": "1",
+        "lastUpdated": "2025-03-03T02:09:23.000-05:00",
+        "source": "#A9ftYtknikFekkjR",
+        "profile": [
+            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+        ],
+        "tag": [
+            {
+                "code": "lformsVersion: 36.3.3"
+            }
+        ]
+    },
+    "url": "http:/lforms-fhir.nlm.nih.gov/baseR4/Questionnaire/44249-1",
+    "title": "PHQ-9 quick depression assessment panel [Reported.PHQ]",
+    "status": "draft",
+    "copyright": "Copyright © Pfizer Inc. All rights reserved. Developed by Drs. Robert L. Spitzer, Janet B.W. Williams, Kurt Kroenke and colleagues, with an educational grant from Pfizer Inc. No permission required to reproduce, translate, display or distribute.",
+    "code": [
+        {
+            "system": "http://loinc.org",
+            "code": "44249-1",
+            "display": "PHQ-9 quick depression assessment panel [Reported.PHQ]"
+        }
+    ],
+    "item": [
+        {
+            "linkId": "phq9",
+            "code": [
+                {
+                    "code": "no-code",
+                    "display": "No code"
+                }
+            ],
+            "text": "Over the last 2 weeks, how often have you been bothered by any of the following problems?",
+            "type": "group",
+            "required": true,
+            "item": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44250-9",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44250-9",
+                            "display": "Little interest or pleasure in doing things"
+                        }
+                    ],
+                    "text": "Little interest or pleasure in doing things",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44255-8",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44255-8",
+                            "display": "Feeling down, depressed, or hopeless"
+                        }
+                    ],
+                    "text": "Feeling down, depressed, or hopeless",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44259-0",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44259-0",
+                            "display": "Trouble falling or staying asleep, or sleeping too much"
+                        }
+                    ],
+                    "text": "Trouble falling or staying asleep, or sleeping too much",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44254-1",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44254-1",
+                            "display": "Feeling tired or having little energy"
+                        }
+                    ],
+                    "text": "Feeling tired or having little energy",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44251-7",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44251-7",
+                            "display": "Poor appetite or overeating"
+                        }
+                    ],
+                    "text": "Poor appetite or overeating",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44258-2",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44258-2",
+                            "display": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down"
+                        }
+                    ],
+                    "text": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44252-5",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44252-5",
+                            "display": "Trouble concentrating on things, such as reading the newspaper or watching television"
+                        }
+                    ],
+                    "text": "Trouble concentrating on things, such as reading the newspaper or watching television",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44253-3",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44253-3",
+                            "display": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual"
+                        }
+                    ],
+                    "text": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/44260-8",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44260-8",
+                            "display": "Thoughts that you would be better off dead, or of hurting yourself in some way"
+                        }
+                    ],
+                    "text": "Thoughts that you would be better off dead, or of hurting yourself in some way",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "0"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 0
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6568-5",
+                                "display": "Not at all"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "1"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 1
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6569-3",
+                                "display": "Several days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "2"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 2
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6570-1",
+                                "display": "More than half the days"
+                            }
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                    "valueString": "3"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                    "valueDecimal": 3
+                                }
+                            ],
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6571-9",
+                                "display": "Nearly every day"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                            "valueCodeableConcept": {
+                                "coding": [
+                                    {
+                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                        "code": "drop-down",
+                                        "display": "Drop down"
+                                    }
+                                ],
+                                "text": "Drop down"
+                            }
+                        }
+                    ],
+                    "linkId": "/69722-7",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "69722-7",
+                            "display": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?"
+                        }
+                    ],
+                    "text": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?",
+                    "type": "choice",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6572-7",
+                                "display": "Not difficult at all"
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6573-5",
+                                "display": "Somewhat difficult"
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6575-0",
+                                "display": "Very difficult"
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "system": "http://loinc.org",
+                                "code": "LA6574-3",
+                                "display": "Extremely difficult"
+                            }
+                        }
+                    ],
+                    "item": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                    "valueCodeableConcept": {
+                                        "coding": [
+                                            {
+                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                "code": "help",
+                                                "display": "Help-Button"
+                                            }
+                                        ],
+                                        "text": "Help-Button"
+                                    }
+                                }
+                            ],
+                            "linkId": "/69722-7-help",
+                            "text": "If you checked off any problems on this questionnaire",
+                            "type": "display"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {Switch, Route, RouteComponentProps} from 'react-router-dom';
 import {Tab, Box, Paper} from '@mui/material';
 import {TabList, TabPanel, TabContext} from '@mui/lab';
 //import { Patient} from './data-services/fhir-types/fhir-r4';
-import {Practitioner, Task} from './data-services/fhir-types/fhir-r4';
+import {Task} from './data-services/fhir-types/fhir-r4';
 
 import HomeIcon from '@mui/icons-material/Home';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
@@ -635,7 +635,7 @@ class App extends React.Component<AppProps, AppState> {
                             c.setState({progressMessage: 'Processed resource ' + j + ' of ' + resources.length});
 
                             let percentComplete = Math.floor((j / resources.length) * 100);
-                            if (percentComplete != progressValue) {
+                            if (percentComplete !== progressValue) {
                                 progressValue = percentComplete;
                                 c.setState({progressValue: progressValue})
                             }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -204,6 +204,13 @@ export default class Home extends React.Component<HomeProps, HomeState> {
                             pathname: '/questionnaire',
                             state: {
                                 patientSummaries: this.props.patientSummaries,
+                                questionnaireId: 'PHQ-9'
+                            }
+                        }}><strong>Depression Assessment</strong></Link><br/>
+                        <Link to={{
+                            pathname: '/questionnaire',
+                            state: {
+                                patientSummaries: this.props.patientSummaries,
                                 questionnaireId: 'PROMIS-29-questionnaire'
                             }
                         }}><strong>General Health Assessment</strong></Link><br/>

--- a/src/components/questionnaire-item/QuestionnaireItemComponent.tsx
+++ b/src/components/questionnaire-item/QuestionnaireItemComponent.tsx
@@ -153,7 +153,7 @@ export default class QuestionnaireItemComponent extends React.Component<any, Que
     return (
       <Card ref={this.questionnaireItemRef} className={"questionnaire-item"} id={this.props.QuestionnaireItem.linkId}>
         <div className="questionnaire-section-header">
-        {(this.props.QuestionnaireItem.linkId !== ('physical-function')) && (this.props.QuestionnaireItem.linkId !== ('112346')) && (this.props.QuestionnaireItem.linkId !== ('caregiver-strain-group'))? (
+        {(this.props.QuestionnaireItem.linkId !== ('physical-function')) && (this.props.QuestionnaireItem.linkId !== ('112346')) && (this.props.QuestionnaireItem.linkId !== ('caregiver-strain-group')) && (this.props.QuestionnaireItem.linkId !== ('phq9')) ? (
               <Button className="btn-outline-secondary previous-button"
                 value={this.props.QuestionnaireItem.linkId}
                 onClick={(event: any) => this.handlePreviousQuestionScroll(event.target.value)}>


### PR DESCRIPTION
This PR adds a new questionnaire definition for PHQ-9 and logic to insert it into the list of assessments that can be taken. The questionnaire definition was adapted from this:

https://lforms-fhir.nlm.nih.gov/baseR4/Questionnaire/44249-1

I added introductory text to clarify that the survey answers should consider the last 2 weeks and I moved all questions onto a single screen.