### PR TITLE
#60: Combine Care Teams from multiple sources

### DIFF
--- a/.env
+++ b/.env
@@ -91,7 +91,7 @@ REACT_APP_LOG_ENABLED=false
 REACT_APP_LOG_API_KEY=<...>
 REACT_APP_LOG_ENDPOINT_URI="http://localhost:8085"
 
-REACT_APP_VERSION="build: v2.9.1-SNAPSHOT (forked @ v2.4.2)"
+REACT_APP_VERSION="build: v2.10.0-SNAPSHOT (forked @ v2.4.2)"
 # Set to have HHS Banner
 REACT_APP_HHS_BANNER=false
 

--- a/src/components/summaries/CareTeamList.tsx
+++ b/src/components/summaries/CareTeamList.tsx
@@ -28,6 +28,41 @@ function resolve(ref?: Reference, members?: Map<string, Practitioner>) {
 export const CareTeamList: React.FC<CareTeamListProps> = (props: CareTeamListProps) => {
   process.env.REACT_APP_DEBUG_LOG === "true" && console.log("CareTeamList component RENDERED!")
 
+  // Combine all participants from all sources into a single array
+  const allParticipants: {
+    participant: CareTeamParticipant;
+    source: String;
+    careTeamMembers: Map<string, Practitioner>;
+  }[] = [];
+
+  props.fhirDataCollection?.forEach(data => {
+    if (data.careTeams) {
+      const partArrays = data.careTeams.map(team => team.participant);
+      const participants = flatten(partArrays) as CareTeamParticipant[];
+
+      participants.forEach(participant => {
+        allParticipants.push({
+          participant,
+          source: data.serverName || "",
+          careTeamMembers: data.careTeamMembers || new Map()
+        });
+      });
+    }
+  });
+
+  // Sort participants - missing names will be last
+  allParticipants.sort((a, b) => {
+    const nameA = resolve(a.participant.member, a.careTeamMembers)?.name?.[0].text
+      ?? a.participant.member?.display
+      ?? a.participant.member?.reference
+      ?? "ZZZ";
+    const nameB = resolve(b.participant.member, b.careTeamMembers)?.name?.[0].text
+      ?? b.participant.member?.display
+      ?? b.participant.member?.reference
+      ?? "ZZZ";
+    return nameA.localeCompare(nameB);
+  });
+
   return (
     <div className="home-view">
       <div className="welcome">
@@ -43,52 +78,41 @@ export const CareTeamList: React.FC<CareTeamListProps> = (props: CareTeamListPro
 
         <h4 className="title">Care Team</h4>
 
-        {props.fhirDataCollection?.map((data, idx) => {
-          let participants: CareTeamParticipant[] = [];
-          if (data.careTeams) {
-            let partArrays = data.careTeams.map(team => team.participant);
-            participants = flatten(partArrays) as CareTeamParticipant[];
-          }
-
-          let careTeamMembers = data.careTeamMembers || new Map();
-
-          return (
-              <div key={idx}>
-
-
-                {participants.length < 1
-                    ? <p>No records found.</p>
-                    :
-                    <>
-                      {participants.map((participant, pIdx) => (
-                          <Summary key={pIdx} id={pIdx} rows={[
-                            {
-                              isHeader: true,
-                              twoColumns: false,
-                              data1: resolve(participant.member, careTeamMembers)?.name?.[0].text
-                                  ?? participant.member?.display
-                                  ?? participant.member?.reference ?? "No name",
-                              data2: '',
-                            },
-                            {
-                              isHeader: false,
-                              twoColumns: false,
-                              data1: "Role: " + (participant.role?.[0].text ?? "No role"),
-                              data2: '',
-                            },
-                            {
-                              isHeader: false,
-                              twoColumns: false,
-                              data1: participant.period === undefined ? '' : "Time Period: " + displayPeriod(participant.period),
-                              data2: '',
-                            },
-                          ]}/>
-                      ))}
-                    </>
-                }
-              </div>
-          )
-        })}
+        {allParticipants.length === 0 ? (
+          <p>No records found.</p>
+        ) : (
+          allParticipants.map(({ participant, source, careTeamMembers }, idx) => (
+            <Summary key={idx} id={idx} rows={[
+              {
+                isHeader: true,
+                twoColumns: false,
+                data1: resolve(participant.member, careTeamMembers)?.name?.[0].text
+                  ?? participant.member?.display
+                  ?? participant.member?.reference
+                  ?? "No name",
+                data2: '',
+              },
+              {
+                isHeader: false,
+                twoColumns: false,
+                data1: "Role: " + (participant.role?.[0].text ?? "No role"),
+                data2: '',
+              },
+              {
+                isHeader: false,
+                twoColumns: false,
+                data1: participant.period === undefined ? '' : "Time Period: " + displayPeriod(participant.period),
+                data2: '',
+              },
+              {
+                isHeader: false,
+                twoColumns: false,
+                data1: "Source: " + source,
+                data2: '',
+              }
+            ]} />
+          ))
+        )}
 
       </div>
     </div>


### PR DESCRIPTION
Combines the care teams from all sources into a single list, sorted by name and with the source displayed on the card.