### PR TITLE
#111: Improve cql execution performance

### DIFF
--- a/src/data-services/mccCqlService.ts
+++ b/src/data-services/mccCqlService.ts
@@ -14,7 +14,7 @@ function getBundleEntries(resources?: Resource[]) {
   return resources?.map((r: Resource) => ({ resource: r })) || []
 }
 
-function getPatientSource(data: FHIRData): unknown {
+function getPatientSource(data: FHIRData, cqlType: string): unknown {
   const practitioners: Practitioner[] = []
   data.resourceRequesters?.forEach((practitioner, id) =>
     practitioners.concat(practitioner)
@@ -22,13 +22,23 @@ function getPatientSource(data: FHIRData): unknown {
   const fhirBundle = {
     resourceType: 'Bundle',
     entry: [{ resource: data.patient }, { resource: data.patientPCP },
-    ...getBundleEntries(data.conditions),
-    ...getBundleEntries(data.medications),
-    ...getBundleEntries(data.serviceRequests),
-    ...getBundleEntries(data.labResults),
-    ...getBundleEntries(data.vitalSigns),
-    ...getBundleEntries(data.surveyResults),
-    ...getBundleEntries(data.goals),
+    ...(cqlType === 'conditions' || cqlType === 'goals'
+      ? getBundleEntries(data.conditions)
+      : []),
+    ...(cqlType === 'medications'
+      ? getBundleEntries(data.medications)
+      : []),
+    ...getBundleEntries(data.serviceRequests), // Not used?
+    ...(cqlType === 'labResults' || cqlType === 'goals'
+      ? getBundleEntries(data.labResults)
+      : []),
+    ...(cqlType === 'vitalSigns' || cqlType === 'goals'
+      ? getBundleEntries(data.vitalSigns)
+      : []),
+    ...getBundleEntries(data.surveyResults), // Maybe used for Screenings?
+    ...(cqlType === 'goals'
+      ? getBundleEntries(data.goals)
+      : []),
     ...getBundleEntries(data.provenance),
     ...getBundleEntries(practitioners),
     ]
@@ -42,7 +52,7 @@ function getPatientSource(data: FHIRData): unknown {
 
 const extractConditionSummary = (fhirData?: FHIRData): ConditionSummary[] | undefined => {
   if (fhirData === undefined) { return undefined }
-  const patientSource = getPatientSource(fhirData!)
+  const patientSource = getPatientSource(fhirData!, 'conditions')
   const extractedSummary = executeLibrary(mccConditionsLibrary, mccCodeService, patientSource)
 
   // console.log("CQL Results in extractConditionSummary: " + JSON.stringify(extractedSummary))
@@ -54,15 +64,17 @@ export const getConditionSummaries = (fhirDataCollection?: FHIRData[]): Conditio
 
   let conditionSummariesMatrix: ConditionSummary[][] | undefined = []
   for (const curFhirData of fhirDataCollection) {
-    const conSummary: ConditionSummary[] | undefined = extractConditionSummary(curFhirData)
-    conditionSummariesMatrix.push(conSummary ? conSummary : [])
+    if (curFhirData.conditions && curFhirData.conditions.length > 0) {
+      const conSummary: ConditionSummary[] | undefined = extractConditionSummary(curFhirData)
+      conditionSummariesMatrix.push(conSummary ? conSummary : [])
+    }
   }
   return conditionSummariesMatrix
 }
 
 const extractGoalSummary = (fhirData?: FHIRData): GoalSummary[] | undefined => {
   if (fhirData === undefined) { return undefined }
-  const patientSource = getPatientSource(fhirData!)
+  const patientSource = getPatientSource(fhirData!, 'goals')
   const extractedSummary = executeLibrary(mccGoalsLibrary, mccCodeService, patientSource)
 
   // console.log("CQL extractedSummary: ", extractedSummary)
@@ -74,15 +86,17 @@ export const getGoalSummaries = (fhirDataCollection?: FHIRData[]): GoalSummary[]
 
   let goalSummariesMatrix: GoalSummary[][] | undefined = []
   for (const curFhirData of fhirDataCollection) {
-    const goalSummary: GoalSummary[] | undefined = extractGoalSummary(curFhirData)
-    goalSummariesMatrix.push(goalSummary ? goalSummary : [])
+    if (curFhirData.goals && curFhirData.goals.length > 0) {
+      const goalSummary: GoalSummary[] | undefined = extractGoalSummary(curFhirData)
+      goalSummariesMatrix.push(goalSummary ? goalSummary : [])
+    }
   }
   return goalSummariesMatrix
 }
 
 const extractLabResultSummary = (fhirData?: FHIRData): ObservationSummary[] | undefined => {
   if (fhirData === undefined) { return undefined }
-  const patientSource = getPatientSource(fhirData!)
+  const patientSource = getPatientSource(fhirData!, 'labResults')
   const extractedSummary = executeLibrary(mccLabResultsLibrary, mccCodeService, patientSource)
 
   // console.log("CQL Results in extractLabResultSummary: " + JSON.stringify(extractedSummary))
@@ -94,15 +108,17 @@ export const getLabResultSummaries = (fhirDataCollection?: FHIRData[]): Observat
 
   let labSummariesMatrix: ObservationSummary[][] | undefined = []
   for (const curFhirData of fhirDataCollection) {
-    const labSummary: ObservationSummary[] | undefined = extractLabResultSummary(curFhirData)
-    labSummariesMatrix.push(labSummary ? labSummary : [])
+    if (curFhirData.labResults && curFhirData.labResults.length > 0) {
+      const labSummary: ObservationSummary[] | undefined = extractLabResultSummary(curFhirData)
+      labSummariesMatrix.push(labSummary ? labSummary : [])
+    }
   }
   return labSummariesMatrix
 }
 
 const extractMedicationSummary = (fhirData?: FHIRData): MedicationSummary[] | undefined => {
   if (fhirData === undefined) { return undefined }
-  const patientSource = getPatientSource(fhirData!)
+  const patientSource = getPatientSource(fhirData!, 'medications')
   const extractedSummary = executeLibrary(mccMedicationsLibrary, mccCodeService, patientSource)
 
   // console.log("CQL Results in extractMedicationSummary: " + JSON.stringify(extractedSummary))
@@ -114,15 +130,17 @@ export const getMedicationSummaries = (fhirDataCollection?: FHIRData[]): Medicat
 
   let medSummariesMatrix: MedicationSummary[][] | undefined = []
   for (const curFhirData of fhirDataCollection) {
-    const medSummary: MedicationSummary[] | undefined = extractMedicationSummary(curFhirData)
-    medSummariesMatrix.push(medSummary ? medSummary : [])
+    if (curFhirData.medications && curFhirData.medications.length > 0) {
+      const medSummary: MedicationSummary[] | undefined = extractMedicationSummary(curFhirData)
+      medSummariesMatrix.push(medSummary ? medSummary : [])
+    }
   }
   return medSummariesMatrix
 }
 
 const extractVitalSignSummary = (fhirData?: FHIRData): ObservationSummary[] | undefined => {
   if (fhirData === undefined) { return undefined }
-  const patientSource = getPatientSource(fhirData!)
+  const patientSource = getPatientSource(fhirData!, 'vitalSigns')
   const extractedSummary = executeLibrary(mccVitalSignsLibrary, mccCodeService, patientSource)
 
   // console.log("CQL Results in extractVitalSignSummary: " + JSON.stringify(extractedSummary))
@@ -134,8 +152,10 @@ export const getVitalSignSummaries = (fhirDataCollection?: FHIRData[]): Observat
 
   let vitalSignSummariesMatrix: ObservationSummary[][] | undefined = []
   for (const curFhirData of fhirDataCollection) {
-    const vitalSummary: ObservationSummary[] | undefined = extractVitalSignSummary(curFhirData)
-    vitalSignSummariesMatrix.push(vitalSummary ? vitalSummary : [])
+    if (curFhirData.vitalSigns && curFhirData.vitalSigns.length > 0) {
+      const vitalSummary: ObservationSummary[] | undefined = extractVitalSignSummary(curFhirData)
+      vitalSignSummariesMatrix.push(vitalSummary ? vitalSummary : [])
+    }
   }
   return vitalSignSummariesMatrix
 }


### PR DESCRIPTION
This has a few targeted improvements to the CQL execution.

1. Don't call the CQL at all if there are no resources of interest in the data set. (e.g., bypass the conditions cql if there are no conditions)
2. Limit the resources provided to the CQL to the subset it needs to execute.