### PR TITLE
#152 - resolved "delay" associated with RxClass integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -766,9 +766,9 @@ class App extends React.Component<AppProps, AppState> {
             await this.setSummaries('getLabResultSummaries()', 'labResultSummaries', getLabResultSummaries)
             await this.setSummaries('getVitalSignSummaries()', 'vitalSignSummaries', getVitalSignSummaries)
 
-            await this.updateLogSummariesCount(this.state.fhirDataCollection) // Logging the count for the patient details bundle.
-
             await this.appendFlagsToMedicationSummaries()
+
+            await this.updateLogSummariesCount(this.state.fhirDataCollection) // Logging the count for the patient details bundle.
         }
     }
 


### PR DESCRIPTION
this wasn't an actual new delay, it's just that the RxClass stuff was originally coded to appear in the middle of the Summaries generation.  turns out, adding that RxClass logic into that space allowed the share-to-SDS operation to kick off, which stalled as soon as the next Summaries began to build.  so it's not that a new delay was introduced, it's that the delay that's always been there was split into 2, giving the impression that a new delay was introduced.